### PR TITLE
[Bugfix] call super update function

### DIFF
--- a/src/scrollcam.ts
+++ b/src/scrollcam.ts
@@ -256,6 +256,8 @@ export default class ScrollingCamera extends Phaser.Cameras.Scene2D.Camera {
 
 
     update(_time, delta) {
+        super.update(_time, delta);
+
         const prop = this._scrollProp;
         this[prop] += this._speed * (delta / 1000);
         this._speed *= this.drag;


### PR DESCRIPTION
I was trying to add a fade effect to this camera, but found that the fade could never run, because the Phaser.Cameras.Scene2D.Camera#update function is never called.

The fix was simple enough, adding a call to super. Everything still works for me, but I have to admit I have not tested it with various use cases.

I hope you will find this useful.

Not sure if there are other methods that need a call to super, I can imagine maybe 'destroy', but I will leave that up to you.